### PR TITLE
Fix: autohide of bottom sheet after adding product to cart

### DIFF
--- a/lib/establishment_detail/view/add_product_to_cart.dart
+++ b/lib/establishment_detail/view/add_product_to_cart.dart
@@ -104,7 +104,7 @@ class _AddToCart extends State<AddToCart> {
               SizedBox(
                 child: ElevatedButton(
                   key: const Key('Cancel_AddProduct_ToCar_flatButton'),
-                  onPressed: () => Navigator.of(context).pop(),
+                  onPressed: () => Navigator.of(context).pop(false),
                   style: AppTheme.secondaryButton,
                   child: const Text('CANCELAR'),
                 ),
@@ -116,11 +116,7 @@ class _AddToCart extends State<AddToCart> {
                     context
                         .read<ProductsListCubit>()
                         .addToCart(widget._product, _counter);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Producto agregado al carrito'),
-                      ),
-                    );
+                    Navigator.of(context).pop(true);
                   },
                   style: AppTheme.secondaryButton,
                   child: const Text('AGREGAR AL CARRITO'),

--- a/lib/establishment_detail/view/products_list.dart
+++ b/lib/establishment_detail/view/products_list.dart
@@ -135,8 +135,8 @@ class _ProductsListItem extends StatelessWidget {
                           ),
                     ),
                     IconButton(
-                      onPressed: () {
-                        showModalBottomSheet<void>(
+                      onPressed: () async {
+                        final productAdded = await showModalBottomSheet<bool>(
                           context: context,
                           builder: (BuildContext _) {
                             return BlocProvider.value(
@@ -145,6 +145,14 @@ class _ProductsListItem extends StatelessWidget {
                             );
                           },
                         );
+                        if (productAdded!) {
+                          // ignore: use_build_context_synchronously
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Producto agregado al carrito.'),
+                            ),
+                          );
+                        }
                       },
                       icon: Icon(
                         MdiIcons.plus,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

El bottom sheet para seleccionar la cantidad de productos a agregar al carrito ahora se cierra automáticamente luego de agregar el producto y muestra un snackbar después confirmando que el producto se agregó.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
