### PR TITLE
Fix: message appearing when click back on appbar

### DIFF
--- a/lib/establishment_detail/view/establishment_detail_page.dart
+++ b/lib/establishment_detail/view/establishment_detail_page.dart
@@ -69,13 +69,17 @@ class _EstablishmentDetailView extends StatelessWidget {
           title: Text(establishment.name),
           leading: IconButton(
             onPressed: () async {
-              final goBack = await showDialog<bool>(
-                context: context,
-                builder: _getGoBackAlert,
-              );
+              if (context.read<ProductsListCubit>().state.cart.isNotEmpty) {
+                final goBack = await showDialog<bool>(
+                  context: context,
+                  builder: _getGoBackAlert,
+                );
 
-              // ignore: use_build_context_synchronously
-              if (goBack!) Navigator.of(context).pop();
+                // ignore: use_build_context_synchronously
+                if (goBack!) Navigator.of(context).pop();
+              } else {
+                Navigator.of(context).pop();
+              }
             },
             icon: const Icon(MdiIcons.arrowLeft),
           ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

El mensaje de confirmación salía siempre que se presionaba el botón de "atrás" del appbar en el detalle del establecimiento, ahora aparece sólo cuando el carrito está con productos.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
