### PR TITLE
add confirmation message when a reservation is delivered

### DIFF
--- a/lib/reservation_detail/view/reservation_detail_page.dart
+++ b/lib/reservation_detail/view/reservation_detail_page.dart
@@ -118,7 +118,7 @@ class _ReservationDetailView extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        'Tu reserva expiro o fue\ncancelada 👀',
+                        'Tu reserva expiró o fue\ncancelada 👀',
                         style: Theme.of(context).textTheme.subtitle1,
                         textAlign: TextAlign.center,
                       ),
@@ -129,6 +129,42 @@ class _ReservationDetailView extends StatelessWidget {
                           Navigator.popUntil(context, (route) {
                             return count++ == 2;
                           });
+                        },
+                        child: const Text('Aceptar'),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        } else if (state.reservation.status == ReservationStatus.delivered) {
+          showDialog<bool>(
+            barrierDismissible: false,
+            context: context,
+            builder: (_) {
+              return Center(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 16,
+                    horizontal: 32,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    color: AppColors.white,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Tu reserva fué entregada! 🎉',
+                        style: Theme.of(context).textTheme.subtitle1,
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pop(context);
                         },
                         child: const Text('Aceptar'),
                       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Al estar dentro de la pantalla de detalle de una reserva pendiente, si dicha reserva es entregada, aparecerá un mensaje emergente indicando que la reserva fué marcada como entregada. Al salir del mensaje se permanece en la pantalla de detalle de reserva, pero al volver a la lista de reservas pendientes, dicha reserva ya no aparecerá.
Antes no había forma de saber que la reserva fué entregada.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
